### PR TITLE
GMP-1675: Fixed broken unit test

### DIFF
--- a/test/controllers/DashboardControllerSpec.scala
+++ b/test/controllers/DashboardControllerSpec.scala
@@ -88,7 +88,7 @@ class DashboardControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
             contentAsString(result) must include(Messages("gmp.single_calculation_link"))
             contentAsString(result) must include(Messages("gmp.bulk_calculation_link"))
             contentAsString(result) must include(Messages("gmp.download_templates_link"))
-            contentAsString(result) must include(Messages("gmp.single_calculation_text"))
+            contentAsString(result) must include(Messages("gmp.single_calculation_text").replace("'", "&#x27;"))
             contentAsString(result) must include(Messages("gmp.bulk_calculation_text"))
             contentAsString(result) must include(Messages("gmp.previous_calculations_text"))
 


### PR DESCRIPTION
I fixed this simply by replacing the offending apostrophe with its Html-encoded equivalent, to match the generate Twirl template. Ideally I'd liked to have used some kind of Html Encode method, but couldn't find anything.

If there is such a thing, let me know and I can change it.