### PR TITLE
DDCNLS-571: Modifies service to use NINO validation from domain library

### DIFF
--- a/app/validation/CsvLineValidator.scala
+++ b/app/validation/CsvLineValidator.scala
@@ -18,11 +18,11 @@ package validation
 
 import org.joda.time.LocalDate
 import org.joda.time.format.DateTimeFormat
+import play.api.Play.current
 import play.api.i18n.Messages
+import play.api.i18n.Messages.Implicits._
 import services.BulkRequestCsvColumn
 import uk.gov.hmrc.time.TaxYear
-import play.api.i18n.Messages.Implicits._
-import play.api.Play.current
 
 trait FieldValidator {
 
@@ -38,12 +38,12 @@ trait FieldValidator {
     }
   }
 
-  def validateNino(nino: String) = {
+  def validateNino(nino: String): Option[String] = {
     val TEMP_NINO = "TN"
     nino match {
       case "" => Some(Messages("gmp.error.mandatory", Messages("gmp.nino")))
-      case x if !NinoValidate.isValid(x) => Some(Messages("gmp.error.nino.invalid"))
       case x if x.toUpperCase().startsWith(TEMP_NINO) => Some(Messages("gmp.error.nino.temporary"))
+      case x if !NinoValidate.isValid(x) => Some(Messages("gmp.error.nino.invalid"))
       case _ => None
     }
   }
@@ -91,14 +91,14 @@ trait FieldValidator {
   }
 
   def validateTerminationDate(value: String) = value match {
-      case "" => None
-      case sm if SMValidate.isValid(sm) => None
-      case x => tryParseDate(x) match {
-        case Some(validDate) if validDate.isBefore(TaxYear(2016).starts) => Some(Messages("gmp.error.csv.termination.oob"))
-        case None => Some(Messages("gmp.error.csv.termination.invalid"))
-        case _ => None
-      }
+    case "" => None
+    case sm if SMValidate.isValid(sm) => None
+    case x => tryParseDate(x) match {
+      case Some(validDate) if validDate.isBefore(TaxYear(2016).starts) => Some(Messages("gmp.error.csv.termination.oob"))
+      case None => Some(Messages("gmp.error.csv.termination.invalid"))
+      case _ => None
     }
+  }
 
   def validateRevalRate(value: String) = {
     value match {
@@ -132,7 +132,9 @@ object CsvLineValidator extends FieldValidator {
 
   def validateLine(line: String) = {
 
-    val columns = line.split(",", -1).map { _.trim }.toList
+    val columns = line.split(",", -1).map {
+      _.trim
+    }.toList
 
     columns.length match {
       case x if x < CSV_COLUMN_COUNT => Some(Map(BulkRequestCsvColumn.LINE_ERROR_TOO_FEW -> Messages("gmp.error.parsing.too_few_columns")))

--- a/app/validation/Validator.scala
+++ b/app/validation/Validator.scala
@@ -18,6 +18,8 @@ package validation
 
 import java.text.{ParseException, SimpleDateFormat}
 
+import uk.gov.hmrc.domain.Nino
+
 import scala.annotation.tailrec
 
 trait Validator {
@@ -44,10 +46,7 @@ object SconValidate extends Validator with Modulus19CheckDigit {
 }
 
 object NinoValidate extends Validator {
-
-  private val validNinoFormat = "(AA|AB|AE|AH|AK|AL|AM|AP|AR|AS|AT|AW|AX|AY|AZ|BA|BB|BE|BH|BK|BL|BM|BT|CA|CB|CE|CH|CK|CL|CR|EA|EB|EE|EH|EK|EL|EM|EP|ER|ES|ET|EW|EX|EY|EZ|GY|HA|HB|HE|HH|HK|HL|HM|HP|HR|HS|HT|HW|HX|HY|HZ|JA|JB|JC|JE|JG|JH|JJ|JK|JL|JM|JN|JP|JR|JS|JT|JW|JX|JY|JZ|KA|KB|KE|KH|KK|KL|KM|KP|KR|KS|KT|KW|KX|KY|KZ|LA|LB|LE|LH|LK|LL|LM|LP|LR|LS|LT|LW|LX|LY|LZ|MA|MW|MX|NA|NB|NE|NH|NL|NM|NP|NR|NS|NW|NX|NY|NZ|OA|OB|OE|OH|OK|OL|OM|OP|OR|OS|OX|PA|PB|PC|PE|PG|PH|PJ|PK|PL|PM|PN|PP|PR|PS|PT|PW|PX|PY|RA|RB|RE|RH|RK|RM|RP|RR|RS|RT|RW|RX|RY|RZ|SA|SB|SC|SE|SG|SH|SJ|SK|SL|SM|SN|SP|SR|SS|ST|SW|SX|SY|SZ|TA|TB|TE|TH|TK|TL|TM|TN|TP|TR|TS|TT|TW|TX|TY|TZ|WA|WB|WE|WK|WL|WM|WP|YA|YB|YE|YH|YK|YL|YM|YP|YR|YS|YT|YW|YX|YY|YZ|ZA|ZB|ZE|ZH|ZK|ZL|ZM|ZP|ZR|ZS|ZT|ZW|ZX|ZY)[0-9]{6}[A-D]"
-
-  override def isValid(nino: String) = nino != null && nino.replaceAll("\\s", "").toUpperCase.matches(validNinoFormat)
+  override def isValid(nino: String): Boolean = Nino.isValid(nino.replaceAll("\\s", ""))
 }
 
 object NameValidate extends Validator {

--- a/test/validation/CsvLineValidatorSpec.scala
+++ b/test/validation/CsvLineValidatorSpec.scala
@@ -307,7 +307,7 @@ class CsvLineValidatorSpec extends FlatSpec with Matchers with OneAppPerSuite {
   }
 
   it should "not report YES as a validation error" in {
-   CsvLineValidator.validateDualCalc("YES") shouldBe empty
+    CsvLineValidator.validateDualCalc("YES") shouldBe empty
   }
 
   it should "not report yes as a validation error" in {

--- a/test/validation/NinoValidatorSpec.scala
+++ b/test/validation/NinoValidatorSpec.scala
@@ -17,58 +17,70 @@
 package validation
 
 import helpers.RandomNino
-import org.scalatest.{WordSpec, Matchers}
+import org.scalatest.{Matchers, WordSpec}
 
 class NinoValidatorSpec extends WordSpec with Matchers {
 
   "The validation of a nino" should {
 
-    "pass with valid NINO" in {validateNino(RandomNino.generate) should equal(true)}
-    "fail with empty string" in { validateNino("") should equal (false) }
-    "fail with only space" in { validateNino("    ") should equal (false) }
+    "pass with valid NINO" in {
+      validateNino(RandomNino.generate) should equal(true)
+    }
+    "fail with empty string" in {
+      validateNino("") should equal(false)
+    }
+    "fail with only space" in {
+      validateNino("    ") should equal(false)
+    }
     "fail with total garbage" in {
-      validateNino("XXX") should equal (false)
-      validateNino("werionownadefwe") should equal (false)
-      validateNino("@£%!)(*&^") should equal (false)
-      validateNino("123456") should equal (false)
+      validateNino("XXX") should equal(false)
+      validateNino("werionownadefwe") should equal(false)
+      validateNino("@£%!)(*&^") should equal(false)
+      validateNino("123456") should equal(false)
     }
     "fail with only one starting letter" in {
-      validateNino("A123456C") should equal (false)
-      validateNino("A1234567C") should equal (false)
+      validateNino("A123456C") should equal(false)
+      validateNino("A1234567C") should equal(false)
     }
     "fail with three starting letters" in {
-      validateNino("ABC12345C") should equal (false)
-      validateNino("ABC123456C") should equal (false)
+      validateNino("ABC12345C") should equal(false)
+      validateNino("ABC123456C") should equal(false)
     }
-    "fail with less than 6 middle digits" in { validateNino("AB12345C") should equal (false) }
-    "fail with more than 6 middle digits" in { validateNino("AB1234567C") should equal (false) }
+    "fail with less than 6 middle digits" in {
+      validateNino("AB12345C") should equal(false)
+    }
+    "fail with more than 6 middle digits" in {
+      validateNino("AB1234567C") should equal(false)
+    }
 
     "fail if we start with invalid characters" in {
-
-      val invalidPrefixes = List("BG", "GB", "NK", "KN", "NT", "ZZ", "CC")
+      val invalidPrefixes = List("BG", "GB", "NK", "KN", "TN", "NT", "ZZ")
       for (v <- invalidPrefixes) {
-        validateNino(v + "123456C") should equal (false)
+        validateNino(v + "123456C") should equal(false)
       }
     }
 
     "pass if we have spaces" in {
       validateNino("C E0 00 00 0A") shouldBe true
-
     }
 
     "fail if the second letter O" in {
-      validateNino("AO123456C") should equal (false)
+      validateNino("AO123456C") should equal(false)
     }
 
     "fail if the suffix is E" in {
-      validateNino("AB123456E") should equal (false)
+      validateNino("AB123456E") should equal(false)
     }
 
     "fail with missing suffix" in {
-      validateNino("AB123456") should equal (false)
+      validateNino("AB123456") should equal(false)
     }
+
+    "pass with 'KC' prefixed NINO" in {
+      validateNino("KC000000A") should equal(true)
+    }
+
   }
 
-  def validateNino(nino: String) = NinoValidate.isValid(nino)
-
+  def validateNino(nino: String): Boolean = NinoValidate.isValid(nino)
 }


### PR DESCRIPTION
Modifies NINO validation to use https://github.com/hmrc/domain/blob/master/src/main/scala/uk/gov/hmrc/domain/Nino.scala.