### PR TITLE
Dls 5098/play UI hmrc upgrade/add hmrc layout

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/GmpContext.scala
+++ b/app/config/GmpContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/GmpModule.scala
+++ b/app/config/GmpModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/GmpSessionCache.scala
+++ b/app/config/GmpSessionCache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/MyErrorHandler.scala
+++ b/app/config/MyErrorHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/ContactFrontendConnector.scala
+++ b/app/connectors/ContactFrontendConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/GmpBulkConnector.scala
+++ b/app/connectors/GmpBulkConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/GmpConnector.scala
+++ b/app/connectors/GmpConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/UpscanConnector.scala
+++ b/app/connectors/UpscanConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/AssetsController.scala
+++ b/app/controllers/AssetsController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/BulkReferenceController.scala
+++ b/app/controllers/BulkReferenceController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/BulkRequestReceivedController.scala
+++ b/app/controllers/BulkRequestReceivedController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/BulkResultsController.scala
+++ b/app/controllers/BulkResultsController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/DashboardController.scala
+++ b/app/controllers/DashboardController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/DateOfLeavingController.scala
+++ b/app/controllers/DateOfLeavingController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/EqualiseController.scala
+++ b/app/controllers/EqualiseController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/FileUploadController.scala
+++ b/app/controllers/FileUploadController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/GmpController.scala
+++ b/app/controllers/GmpController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/IncorrectlyEncodedController.scala
+++ b/app/controllers/IncorrectlyEncodedController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/InflationProofController.scala
+++ b/app/controllers/InflationProofController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/MemberDetailsController.scala
+++ b/app/controllers/MemberDetailsController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/MoreBulkResultsController.scala
+++ b/app/controllers/MoreBulkResultsController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/PensionDetailsController.scala
+++ b/app/controllers/PensionDetailsController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/ResultsController.scala
+++ b/app/controllers/ResultsController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/RevaluationController.scala
+++ b/app/controllers/RevaluationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/RevaluationRateController.scala
+++ b/app/controllers/RevaluationRateController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/ScenarioController.scala
+++ b/app/controllers/ScenarioController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/SessionCacheController.scala
+++ b/app/controllers/SessionCacheController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/auth/AuthAction.scala
+++ b/app/controllers/auth/AuthAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/auth/ExternalUrls.scala
+++ b/app/controllers/auth/ExternalUrls.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/auth/UUIDGenerator.scala
+++ b/app/controllers/auth/UUIDGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/test/TestController.scala
+++ b/app/controllers/test/TestController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/events/ContributionsAndEarningsEvent.scala
+++ b/app/events/ContributionsAndEarningsEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/events/ExitQuestionnaireEvent.scala
+++ b/app/events/ExitQuestionnaireEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/events/GmpBusinessEvent.scala
+++ b/app/events/GmpBusinessEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/BulkReferenceForm.scala
+++ b/app/forms/BulkReferenceForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/DateOfLeavingForm.scala
+++ b/app/forms/DateOfLeavingForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/EqualiseForm.scala
+++ b/app/forms/EqualiseForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/ExitQuestionnaireForm.scala
+++ b/app/forms/ExitQuestionnaireForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/InflationProofForm.scala
+++ b/app/forms/InflationProofForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/MemberDetailsForm.scala
+++ b/app/forms/MemberDetailsForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/PensionDetailsForm.scala
+++ b/app/forms/PensionDetailsForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/RevaluationForm.scala
+++ b/app/forms/RevaluationForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/RevaluationRateForm.scala
+++ b/app/forms/RevaluationRateForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/ScenarioForm.scala
+++ b/app/forms/ScenarioForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/package.scala
+++ b/app/forms/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/metrics/ApplicationMetrics.scala
+++ b/app/metrics/ApplicationMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/BulkCalculationRequest.scala
+++ b/app/models/BulkCalculationRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/BulkPreviousRequest.scala
+++ b/app/models/BulkPreviousRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/BulkReference.scala
+++ b/app/models/BulkReference.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/BulkResultsSummary.scala
+++ b/app/models/BulkResultsSummary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/CalculationRequest.scala
+++ b/app/models/CalculationRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/CalculationResponse.scala
+++ b/app/models/CalculationResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/CalculationType.scala
+++ b/app/models/CalculationType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/Dashboard.scala
+++ b/app/models/Dashboard.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/Equalise.scala
+++ b/app/models/Equalise.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/ExitQuestionnaire.scala
+++ b/app/models/ExitQuestionnaire.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/GMPDate.scala
+++ b/app/models/GMPDate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/GmpBulkSession.scala
+++ b/app/models/GmpBulkSession.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/GmpSession.scala
+++ b/app/models/GmpSession.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/InflationProof.scala
+++ b/app/models/InflationProof.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/Leaving.scala
+++ b/app/models/Leaving.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/MemberDetails.scala
+++ b/app/models/MemberDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/Nino.scala
+++ b/app/models/Nino.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/PensionDetails.scala
+++ b/app/models/PensionDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/RevaluationDate.scala
+++ b/app/models/RevaluationDate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/RevaluationRate.scala
+++ b/app/models/RevaluationRate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/ValidateSconRequest.scala
+++ b/app/models/ValidateSconRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/ValidateSconResponse.scala
+++ b/app/models/ValidateSconResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/upscan/UploadCallback.scala
+++ b/app/models/upscan/UploadCallback.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/upscan/UploadStatus.scala
+++ b/app/models/upscan/UploadStatus.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/upscan/UpscanInitiateRequest.scala
+++ b/app/models/upscan/UpscanInitiateRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/upscan/UpscanInitiateResponse.scala
+++ b/app/models/upscan/UpscanInitiateResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/BulkEntityProcessor.scala
+++ b/app/services/BulkEntityProcessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/BulkRequestCreationService.scala
+++ b/app/services/BulkRequestCreationService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/SessionService.scala
+++ b/app/services/SessionService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/UpscanService.scala
+++ b/app/services/UpscanService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/validation/CsvLineValidator.scala
+++ b/app/validation/CsvLineValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/validation/Validator.scala
+++ b/app/validation/Validator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/ViewHelpers.scala
+++ b/app/views/ViewHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/Views.scala
+++ b/app/views/Views.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/bulk_reference.scala.html
+++ b/app/views/bulk_reference.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/bulk_reference.scala.html
+++ b/app/views/bulk_reference.scala.html
@@ -18,7 +18,7 @@
 @import views.html.helpers._
 @import views.ViewHelpers
 
-@this(gmpMain: gmp_main, viewHelpers: ViewHelpers)
+@this(gmpMain: gmp_main_old, viewHelpers: ViewHelpers)
 
 @(bulkReferenceForm: Form[models.BulkReference])(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/bulk_request_received.scala.html
+++ b/app/views/bulk_request_received.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/bulk_request_received.scala.html
+++ b/app/views/bulk_request_received.scala.html
@@ -17,7 +17,7 @@
 @import config.ApplicationConfig
 @import views.html.helpers._
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @(reference: String)(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/bulk_results.scala.html
+++ b/app/views/bulk_results.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/bulk_results.scala.html
+++ b/app/views/bulk_results.scala.html
@@ -16,7 +16,7 @@
 
 @import config.ApplicationConfig
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @(bulkResultsSummary: BulkResultsSummary, uploadReference: String, comingFromPage: Int)(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/bulk_results_not_found.scala.html
+++ b/app/views/bulk_results_not_found.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/bulk_results_not_found.scala.html
+++ b/app/views/bulk_results_not_found.scala.html
@@ -17,7 +17,7 @@
 @import config.ApplicationConfig
 @import views.html.helpers._
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @()(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/bulk_wrong_user.scala.html
+++ b/app/views/bulk_wrong_user.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/bulk_wrong_user.scala.html
+++ b/app/views/bulk_wrong_user.scala.html
@@ -18,7 +18,7 @@
 @import views.html.helpers._
 @import controllers.auth.ExternalUrls
 
-@this(gmpMain: gmp_main, externalUrls: ExternalUrls)
+@this(gmpMain: gmp_main_old, externalUrls: ExternalUrls)
 
 @()(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/contributions_earnings.scala.html
+++ b/app/views/contributions_earnings.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/contributions_earnings.scala.html
+++ b/app/views/contributions_earnings.scala.html
@@ -16,7 +16,7 @@
 
 @import config.ApplicationConfig
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @(calculationResponse:CalculationResponse)(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/dashboard.scala.html
+++ b/app/views/dashboard.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/dashboard.scala.html
+++ b/app/views/dashboard.scala.html
@@ -18,7 +18,7 @@
 @import views.html.helpers._
 @import org.joda.time.{Days, LocalDate, LocalDateTime}
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @(previousBulkCalculations: List[BulkPreviousRequest])(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/dateofleaving.scala.html
+++ b/app/views/dateofleaving.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/dateofleaving.scala.html
+++ b/app/views/dateofleaving.scala.html
@@ -19,7 +19,7 @@
 @import models.Leaving
 @import views.ViewHelpers
 
-@this(gmpMain: gmp_main, viewHelpers: ViewHelpers)
+@this(gmpMain: gmp_main_old, viewHelpers: ViewHelpers)
 
 @(dateOfLeavingForm: Form[models.Leaving],scenario: String)(implicit request: Request[_], messages: Messages, applicationConfig: config.ApplicationConfig)
 

--- a/app/views/equalise.scala.html
+++ b/app/views/equalise.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/equalise.scala.html
+++ b/app/views/equalise.scala.html
@@ -18,7 +18,7 @@
 @import views.html.helpers._
 @import views.ViewHelpers
 
-@this(gmpMain: gmp_main, viewHelpers: ViewHelpers)
+@this(gmpMain: gmp_main_old, viewHelpers: ViewHelpers)
 
 @(equaliseForm: Form[models.Equalise])(implicit request: Request[_], messages: Messages, applicationConfig: ApplicationConfig)
 

--- a/app/views/failure.scala.html
+++ b/app/views/failure.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/failure.scala.html
+++ b/app/views/failure.scala.html
@@ -17,7 +17,7 @@
 @import config.ApplicationConfig
 @import views.html.helpers._
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @(message: String, header: String, title: String)(implicit request: Request[_], messages: Messages, applicationConfig: ApplicationConfig)
 

--- a/app/views/global_error.scala.html
+++ b/app/views/global_error.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/global_page_not_found.scala.html
+++ b/app/views/global_page_not_found.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/global_page_not_found.scala.html
+++ b/app/views/global_page_not_found.scala.html
@@ -17,7 +17,7 @@
 @import play.api.i18n.Messages
 @import play.twirl.api.HtmlFormat
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @(
     signOutEnabled: Boolean = true,

--- a/app/views/gmp_main.scala.html
+++ b/app/views/gmp_main.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/gmp_main.scala.html
+++ b/app/views/gmp_main.scala.html
@@ -15,63 +15,60 @@
  *@
 
 @import views.ViewHelpers
+@import config.ApplicationConfig
+@import views.helpers.MainParams
 
-@this(main: views.html.main,
-      viewHelpers: ViewHelpers)
+@this(layout: views.html.layout,
+        viewHelpers: ViewHelpers)
 
 @(title: String,
-pageScripts: Option[Html] = None,
-scriptElem: Option[Html] = None,
-userLoggedIn: Boolean = true,
-supportLinkEnabled: Boolean = true,
-mainClass : Option[String] = None,
-signOutEnabled: Boolean = true,
-showSignOutLink: Boolean = true,
-showUserResearchBanner: Boolean = false,
-dashboardLinkEnabled:Boolean = false,
-pageHeading: Option[String] = None,
-customHead: Option[Html] = None)(mainContent: Html)(implicit request: Request[_], messages: Messages, appConfig:config.ApplicationConfig)
+        pageScripts: Option[Html] = None,
+        scriptElem: Option[Html] = None,
+        userLoggedIn: Boolean = true,
+        supportLinkEnabled: Boolean = true,
+        mainClass : Option[String] = None,
+        signOutEnabled: Boolean = true,
+        showSignOutLink: Boolean = true,
+        showUserResearchBanner: Boolean = false,
+        dashboardLinkEnabled:Boolean = false,
+        pageHeading: Option[String] = None,
+        customHead: Option[Html] = None
+)(mainContent: Html)(implicit request: Request[_], messages: Messages, appConfig: ApplicationConfig)
 
-@getHelpForm = @{viewHelpers.reportAProblemLink(appConfig.reportAProblemPartialUrl, appConfig.reportAProblemNonJSUrl)}
-
+@getHelpForm = @{viewHelpers.reportAProblemLink(appConfig.reportAProblemPartialUrl,
+    appConfig.reportAProblemNonJSUrl)}
 
 @linkElement = {
-  <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/gmp.css")'/>
-  <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/urBanner.css")' media="screen" type="text/css" />
-  <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/timeout-dialog.css")'/>
-  <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/palette.css")'/>
-  <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/focus.css")'/>
-}
-
-@main(
-  applicationConfig = appConfig,
-  title = title,
-  userLoggedIn = userLoggedIn,
-  getHelpForm = getHelpForm,
-  mainClass = mainClass,
-  linkElement = Some(linkElement),
-  isUserResearchBannerVisible = showUserResearchBanner,
-  scriptElement = Some(scriptElement),
-  signOutEnabled = signOutEnabled,
-  customHead = customHead) {
-
-    @mainContent
+    <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/gmp.css")'/>
+    <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/urBanner.css")' media="screen" type="text/css" />
+    <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/timeout-dialog.css")'/>
+    <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/palette.css")'/>
+    <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/focus.css")'/>
 }
 
 @scriptElement = {
     <script src="@controllers.routes.AssetsController.at("javascripts/timeout-dialog.js")"></script>
     <script>
-    @if(userLoggedIn) {
-        $.timeoutDialog({timeout: @appConfig.timeout,
-                         countdown: @appConfig.timeoutCountdown,
-                         keep_alive_url: "@controllers.routes.ApplicationController.keepAlive",
-                         logout_url: "@controllers.routes.ApplicationController.signout",
-                         logout_redirect_url: "@controllers.routes.ApplicationController.signout",
-                         restart_on_yes: true, background_no_scroll: true});
-       var dialogOpen;
-    }
+            @if(userLoggedIn) {
+            $.timeoutDialog({timeout: @appConfig.timeout,
+                countdown: @appConfig.timeoutCountdown,
+                keep_alive_url: "@controllers.routes.ApplicationController.keepAlive",
+                logout_url: "@controllers.routes.ApplicationController.signout",
+                logout_redirect_url: "@controllers.routes.ApplicationController.signout",
+                restart_on_yes: true, background_no_scroll: true});
+            var dialogOpen;
+            }
 
-  </script>
+    </script>
 @scriptElem
-  @pageScripts
+@pageScripts
 }
+@layout(
+    MainParams(title = title,
+        userLoggedIn = userLoggedIn,
+        mainClass = mainClass,
+        linkElement = Some(linkElement),
+        isUserResearchBannerVisible = showUserResearchBanner,
+        scriptElement = Some(scriptElement),
+        signOutEnabled = signOutEnabled,
+        customHead = customHead)){@mainContent}

--- a/app/views/gmp_main_old.scala.html
+++ b/app/views/gmp_main_old.scala.html
@@ -1,0 +1,77 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import views.ViewHelpers
+
+@this(main: views.html.main,
+      viewHelpers: ViewHelpers)
+
+@(title: String,
+pageScripts: Option[Html] = None,
+scriptElem: Option[Html] = None,
+userLoggedIn: Boolean = true,
+supportLinkEnabled: Boolean = true,
+mainClass : Option[String] = None,
+signOutEnabled: Boolean = true,
+showSignOutLink: Boolean = true,
+showUserResearchBanner: Boolean = false,
+dashboardLinkEnabled:Boolean = false,
+pageHeading: Option[String] = None,
+customHead: Option[Html] = None)(mainContent: Html)(implicit request: Request[_], messages: Messages, appConfig:config.ApplicationConfig)
+
+@getHelpForm = @{viewHelpers.reportAProblemLink(appConfig.reportAProblemPartialUrl, appConfig.reportAProblemNonJSUrl)}
+
+
+@linkElement = {
+  <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/gmp.css")'/>
+  <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/urBanner.css")' media="screen" type="text/css" />
+  <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/timeout-dialog.css")'/>
+  <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/palette.css")'/>
+  <link rel="stylesheet" href='@controllers.routes.AssetsController.at("stylesheets/focus.css")'/>
+}
+
+@main(
+  applicationConfig = appConfig,
+  title = title,
+  userLoggedIn = userLoggedIn,
+  getHelpForm = getHelpForm,
+  mainClass = mainClass,
+  linkElement = Some(linkElement),
+  isUserResearchBannerVisible = showUserResearchBanner,
+  scriptElement = Some(scriptElement),
+  signOutEnabled = signOutEnabled,
+  customHead = customHead) {
+
+    @mainContent
+}
+
+@scriptElement = {
+    <script src="@controllers.routes.AssetsController.at("javascripts/timeout-dialog.js")"></script>
+    <script>
+    @if(userLoggedIn) {
+        $.timeoutDialog({timeout: @appConfig.timeout,
+                         countdown: @appConfig.timeoutCountdown,
+                         keep_alive_url: "@controllers.routes.ApplicationController.keepAlive",
+                         logout_url: "@controllers.routes.ApplicationController.signout",
+                         logout_redirect_url: "@controllers.routes.ApplicationController.signout",
+                         restart_on_yes: true, background_no_scroll: true});
+       var dialogOpen;
+    }
+
+  </script>
+@scriptElem
+  @pageScripts
+}

--- a/app/views/helpers/GmpDateFormatter.scala
+++ b/app/views/helpers/GmpDateFormatter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/helpers/MainParams.scala
+++ b/app/views/helpers/MainParams.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.helpers
+import play.twirl.api.Html
+
+case class MainParams(title: String,
+                      pageScripts: Option[Html] = None,
+                      scriptElem: Option[Html] = None,
+                      userLoggedIn: Boolean = true,
+                      supportLinkEnabled: Boolean = true,
+                      linkElement: Option[Html] = None,
+                      scriptElement: Option[Html] = None,
+                      mainClass : Option[String] = None,
+                      signOutEnabled: Boolean = true,
+                      showSignOutLink: Boolean = true,
+                      showUserResearchBanner: Boolean = false,
+                      dashboardLinkEnabled:Boolean = false,
+                      pageHeading: Option[String] = None,
+                      customHead: Option[Html] = None,
+                      isUserResearchBannerVisible:Boolean = false)

--- a/app/views/helpers/commonHelper.scala.html
+++ b/app/views/helpers/commonHelper.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/helpers/errorSummary.scala.html
+++ b/app/views/helpers/errorSummary.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/helpers/fullWidthBanner.scala.html
+++ b/app/views/helpers/fullWidthBanner.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/helpers/gmpInput.scala.html
+++ b/app/views/helpers/gmpInput.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/helpers/gmpRadioGroup.scala.html
+++ b/app/views/helpers/gmpRadioGroup.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/helpers/gmpTextArea.scala.html
+++ b/app/views/helpers/gmpTextArea.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/helpers/groupError.scala.html
+++ b/app/views/helpers/groupError.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/helpers/package.scala
+++ b/app/views/helpers/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/helpers/spinner.scala.html
+++ b/app/views/helpers/spinner.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/back_link.scala.html
+++ b/app/views/includes/back_link.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/back_to_dashboard_link.scala.html
+++ b/app/views/includes/back_to_dashboard_link.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/bulk_query_handling_message.scala.html
+++ b/app/views/includes/bulk_query_handling_message.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/bulk_results_all.scala.html
+++ b/app/views/includes/bulk_results_all.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/bulk_results_failed.scala.html
+++ b/app/views/includes/bulk_results_failed.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/bulk_results_successful.scala.html
+++ b/app/views/includes/bulk_results_successful.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/contributions_and_earnings_error.scala.html
+++ b/app/views/includes/contributions_and_earnings_error.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/contributions_earnings.scala.html
+++ b/app/views/includes/contributions_earnings.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/conts_and_earnings_link.scala.html
+++ b/app/views/includes/conts_and_earnings_link.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/global_error.scala.html
+++ b/app/views/includes/global_error.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/member_details_result.scala.html
+++ b/app/views/includes/member_details_result.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/multi_error.scala.html
+++ b/app/views/includes/multi_error.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/multi_results.scala.html
+++ b/app/views/includes/multi_results.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/multi_results_table.scala.html
+++ b/app/views/includes/multi_results_table.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/print_page.scala.html
+++ b/app/views/includes/print_page.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/report_problem.scala.html
+++ b/app/views/includes/report_problem.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/request_another_button.scala.html
+++ b/app/views/includes/request_another_button.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/result_header_subheader.scala.html
+++ b/app/views/includes/result_header_subheader.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/results_table.scala.html
+++ b/app/views/includes/results_table.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/survivor_disclaimer.scala.html
+++ b/app/views/includes/survivor_disclaimer.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/includes/upscan_file_upload_form.scala.html
+++ b/app/views/includes/upscan_file_upload_form.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/incorrectlyEncoded.scala.html
+++ b/app/views/incorrectlyEncoded.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/incorrectlyEncoded.scala.html
+++ b/app/views/incorrectlyEncoded.scala.html
@@ -17,7 +17,7 @@
 @import config.ApplicationConfig
 @import views.html.helpers._
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @(message: String, header: String)(implicit request: Request[_], messages: Messages, applicationConfig: ApplicationConfig)
 

--- a/app/views/inflation_proof.scala.html
+++ b/app/views/inflation_proof.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/inflation_proof.scala.html
+++ b/app/views/inflation_proof.scala.html
@@ -18,7 +18,7 @@
 @import views.html.helpers._
 @import views.ViewHelpers
 
-@this(gmpMain: gmp_main, viewHelpers: ViewHelpers)
+@this(gmpMain: gmp_main_old, viewHelpers: ViewHelpers)
 
 @(inflationProofForm: Form[models.InflationProof])(implicit request: Request[_], messages: Messages, applicationConfig: ApplicationConfig)
 

--- a/app/views/layout.scala.html
+++ b/app/views/layout.scala.html
@@ -36,15 +36,3 @@
         Some(appConfig.urBannerLink)} else {None},
     nonce = CSPNonce.get,
 )(contentBlock)
-    © 2022 GitHub, Inc.
-    Terms
-    Privacy
-    Security
-    Status
-    Docs
-    Contact GitHub
-    Pricing
-    API
-    Training
-    Blog
-    About

--- a/app/views/layout.scala.html
+++ b/app/views/layout.scala.html
@@ -1,0 +1,50 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcLayout
+@import views.html.helper.CSPNonce
+@import config.ApplicationConfig
+@import views.ViewHelpers
+@import views.helpers.MainParams
+
+@this(hmrcLayout: HmrcLayout, viewHelpers: ViewHelpers, appConfig: ApplicationConfig)
+
+@(params: MainParams
+)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
+
+@getHelpForm = @{viewHelpers.reportAProblemLink(appConfig.reportAProblemPartialUrl, appConfig.reportAProblemNonJSUrl)}
+
+
+@hmrcLayout(
+    pageTitle = Some(params.title),
+    isWelshTranslationAvailable = false,
+    signOutUrl = Some(routes.ApplicationController.signout.url),
+    userResearchBannerUrl = if(appConfig.urBannerToggle) {
+        Some(appConfig.urBannerLink)} else {None},
+    nonce = CSPNonce.get,
+)(contentBlock)
+    © 2022 GitHub, Inc.
+    Terms
+    Privacy
+    Security
+    Status
+    Docs
+    Contact GitHub
+    Pricing
+    API
+    Training
+    Blog
+    About

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/member_details.scala.html
+++ b/app/views/member_details.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/member_details.scala.html
+++ b/app/views/member_details.scala.html
@@ -18,7 +18,7 @@
 @import views.html.helpers._
 @import views.ViewHelpers
 
-@this(gmpMain: gmp_main, viewHelpers: ViewHelpers)
+@this(gmpMain: gmp_main_old, viewHelpers: ViewHelpers)
 
 @(memberDetailsForm: Form[models.MemberDetails])(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/more_bulk_results.scala.html
+++ b/app/views/more_bulk_results.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/more_bulk_results.scala.html
+++ b/app/views/more_bulk_results.scala.html
@@ -18,7 +18,7 @@
 @import views.html.helpers._
 @import org.joda.time.{Days, LocalDateTime, LocalDate}
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @(previousBulkCalculations: List[BulkPreviousRequest])(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/pension_details.scala.html
+++ b/app/views/pension_details.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/pension_details.scala.html
+++ b/app/views/pension_details.scala.html
@@ -18,7 +18,7 @@
 @import views.html.helpers._
 @import views.ViewHelpers
 
-@this(gmpMain: gmp_main, viewHelpers: ViewHelpers)
+@this(gmpMain: gmp_main_old, viewHelpers: ViewHelpers)
 
 @(pensionDetailsForm: Form[models.PensionDetails])(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/results.scala.html
+++ b/app/views/results.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/results.scala.html
+++ b/app/views/results.scala.html
@@ -16,7 +16,7 @@
 
 @import config.ApplicationConfig
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @(
         calculationResponse:CalculationResponse,

--- a/app/views/revaluation.scala.html
+++ b/app/views/revaluation.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/revaluation.scala.html
+++ b/app/views/revaluation.scala.html
@@ -18,7 +18,7 @@
 @import views.html.helpers._
 @import views.ViewHelpers
 
-@this(gmpMain: gmp_main, viewHelpers: ViewHelpers)
+@this(gmpMain: gmp_main_old, viewHelpers: ViewHelpers)
 
 @(revaluationForm: Form[models.RevaluationDate])(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/revaluation_rate.scala.html
+++ b/app/views/revaluation_rate.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/revaluation_rate.scala.html
+++ b/app/views/revaluation_rate.scala.html
@@ -19,7 +19,7 @@
 @import models.CalculationType
 @import views.ViewHelpers
 
-@this(gmpMain: gmp_main, viewHelpers: ViewHelpers)
+@this(gmpMain: gmp_main_old, viewHelpers: ViewHelpers)
 
 @(revaluationRateForm: Form[models.RevaluationRate], session: GmpSession)(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/scenario.scala.html
+++ b/app/views/scenario.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/scenario.scala.html
+++ b/app/views/scenario.scala.html
@@ -18,7 +18,7 @@
 @import views.html.helpers._
 @import views.ViewHelpers
 
-@this(gmpMain: gmp_main, viewHelpers: ViewHelpers)
+@this(gmpMain: gmp_main_old, viewHelpers: ViewHelpers)
 
 
 @(calculationType: Form[models.CalculationType])(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)

--- a/app/views/thank_you.scala.html
+++ b/app/views/thank_you.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/thank_you.scala.html
+++ b/app/views/thank_you.scala.html
@@ -17,7 +17,7 @@
 @import config.ApplicationConfig
 @import views.html.helpers._
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @()(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/unauthorised.scala.html
+++ b/app/views/unauthorised.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/unauthorised.scala.html
+++ b/app/views/unauthorised.scala.html
@@ -16,7 +16,7 @@
 
 @import config.ApplicationConfig
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @()(implicit request: Request[_], messages: Messages, ac:ApplicationConfig)
 

--- a/app/views/upload_result.scala.html
+++ b/app/views/upload_result.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/upload_result.scala.html
+++ b/app/views/upload_result.scala.html
@@ -20,7 +20,7 @@
 @import views.html.helpers.spinner
 @import models.upscan.UploadedFailed
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @(status : UploadStatus)(implicit request: Request[_], messages: Messages, appConfig: ApplicationConfig)
 

--- a/app/views/upscan_csv_file_upload.scala.html
+++ b/app/views/upscan_csv_file_upload.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/upscan_csv_file_upload.scala.html
+++ b/app/views/upscan_csv_file_upload.scala.html
@@ -19,7 +19,7 @@
 @import views.html.includes.upscan_file_upload_form
 @import views.html.helpers._
 
-@this(gmpMain: gmp_main)
+@this(gmpMain: gmp_main_old)
 
 @(upscanInitiateResponse: UpscanInitiateResponse)(implicit request: Request[_], messages: Messages,ac:ApplicationConfig)
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,5 +1,6 @@
 # microservice specific routes
 
+->          /hmrc-frontend                                hmrcfrontend.Routes
 ->          /template                                     template.Routes
 
 GET         /assets/*file                                 controllers.AssetsController.at(path="/public", file)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2021 HM Revenue & Customs
+# Copyright 2022 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,6 +7,7 @@ object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     ws,
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28"  % "5.13.0",
+    "uk.gov.hmrc" %% "play-frontend-hmrc"          % "3.15.0-play-28",
     "uk.gov.hmrc" %% "domain"                      % "8.1.0-play-28",
     "uk.gov.hmrc" %% "http-caching-client"         % "9.6.0-play-28",
     "uk.gov.hmrc" %% "tax-year"                    % "1.1.0",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,17 +6,17 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-28"  % "5.12.0",
-    "uk.gov.hmrc" %% "domain"                      % "6.2.0-play-28",
-    "uk.gov.hmrc" %% "http-caching-client"         % "9.5.0-play-28",
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-28"  % "5.13.0",
+    "uk.gov.hmrc" %% "domain"                      % "8.1.0-play-28",
+    "uk.gov.hmrc" %% "http-caching-client"         % "9.6.0-play-28",
     "uk.gov.hmrc" %% "tax-year"                    % "1.1.0",
-    "uk.gov.hmrc" %% "play-partials"               % "8.2.0-play-28",
-    "uk.gov.hmrc" %% "emailaddress"                % "3.5.0",
-    "uk.gov.hmrc" %% "govuk-template"              % "5.69.0-play-28",
-    "uk.gov.hmrc" %% "play-ui"                     % "9.6.0-play-28",
-    "com.typesafe.play" %% "play-json-joda"        % "2.8.1",
+    "uk.gov.hmrc" %% "play-partials"               % "8.3.0-play-28",
+    "uk.gov.hmrc" %% "emailaddress"                % "3.6.0",
+    "uk.gov.hmrc" %% "govuk-template"              % "5.77.0-play-28",
+    "uk.gov.hmrc" %% "play-ui"                     % "9.10.0-play-28",
+    "com.typesafe.play" %% "play-json-joda"        % "2.9.2",
     "com.typesafe.play" %% "play-iteratees"        % "2.6.1",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.3",
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.3",
     compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.5" cross CrossVersion.full),
     "com.github.ghik" % "silencer-lib" % "1.7.5" % Provided cross CrossVersion.full
   )
@@ -26,10 +26,10 @@ object AppDependencies {
     "org.scalatestplus.play"  %% "scalatestplus-play" % "5.1.0",
     "org.scalatestplus"      %% "scalatestplus-mockito"   % "1.0.0-M2",
     "org.pegdown"             %  "pegdown"            % "1.6.0",
-    "org.jsoup"               %  "jsoup"              % "1.14.2",
+    "org.jsoup"               %  "jsoup"              % "1.14.3",
     "com.typesafe.play"       %% "play-test"          % PlayVersion.current,
     "org.mockito"             %  "mockito-core"       % "1.10.19",
-    "com.github.tomakehurst"  %  "wiremock-jre8"      % "2.28.0",
+    "com.github.tomakehurst"  %  "wiremock-jre8"      % "2.33.2",
     "com.vladsch.flexmark" % "flexmark-all" % "0.36.8"
   ).map(_ % "test")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.5.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.jcenterRepo
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 

--- a/test/config/ApplicationConfigSpec.scala
+++ b/test/config/ApplicationConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/ContactFrontendConnectorSpec.scala
+++ b/test/connectors/ContactFrontendConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/GmpBulkConnectorSpec.scala
+++ b/test/connectors/GmpBulkConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/GmpConnectorSpec.scala
+++ b/test/connectors/GmpConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/UpscanConnectorSpec.scala
+++ b/test/connectors/UpscanConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/ApplicationControllerSpec.scala
+++ b/test/controllers/ApplicationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/BulkReferenceControllerSpec.scala
+++ b/test/controllers/BulkReferenceControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/BulkRequestReceivedControllerSpec.scala
+++ b/test/controllers/BulkRequestReceivedControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/BulkResultsControllerSpec.scala
+++ b/test/controllers/BulkResultsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/DashboardControllerSpec.scala
+++ b/test/controllers/DashboardControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/DateOfLeavingControllerSpec.scala
+++ b/test/controllers/DateOfLeavingControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/EqualiseControllerSpec.scala
+++ b/test/controllers/EqualiseControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/FakeGmpContext.scala
+++ b/test/controllers/FakeGmpContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/FileUploadControllerSpec.scala
+++ b/test/controllers/FileUploadControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/GmpControllerSpec.scala
+++ b/test/controllers/GmpControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/IncorrectlyEncodedControllerSpec.scala
+++ b/test/controllers/IncorrectlyEncodedControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/InflationProofControllerSpec.scala
+++ b/test/controllers/InflationProofControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/MemberDetailsControllerSpec.scala
+++ b/test/controllers/MemberDetailsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/MoreBulkResultsControllerSpec.scala
+++ b/test/controllers/MoreBulkResultsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/PensionDetailsControllerSpec.scala
+++ b/test/controllers/PensionDetailsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/ResultsControllerSpec.scala
+++ b/test/controllers/ResultsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/RevaluationControllerSpec.scala
+++ b/test/controllers/RevaluationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/RevaluationRateControllerSpec.scala
+++ b/test/controllers/RevaluationRateControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/ScenarioControllerSpec.scala
+++ b/test/controllers/ScenarioControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/SessionCacheControllerSpec.scala
+++ b/test/controllers/SessionCacheControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/auth/AuthActionSpec.scala
+++ b/test/controllers/auth/AuthActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/auth/ExternalUrlsSpec.scala
+++ b/test/controllers/auth/ExternalUrlsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/auth/FakeAuthAction.scala
+++ b/test/controllers/auth/FakeAuthAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/auth/UUIDGeneratorSpec.scala
+++ b/test/controllers/auth/UUIDGeneratorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/BulkReferenceFormSpec.scala
+++ b/test/forms/BulkReferenceFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/DateOfLeavingFormSpec.scala
+++ b/test/forms/DateOfLeavingFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/EqualiseFormSpec.scala
+++ b/test/forms/EqualiseFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/ExitQuestionnaireFormSpec.scala
+++ b/test/forms/ExitQuestionnaireFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/InflationProofFormSpec.scala
+++ b/test/forms/InflationProofFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/MemberDetailsFormSpec.scala
+++ b/test/forms/MemberDetailsFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/PensionDetailsFormSpec.scala
+++ b/test/forms/PensionDetailsFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/RevaluationFormSpec.scala
+++ b/test/forms/RevaluationFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/RevaluationRateFormSpec.scala
+++ b/test/forms/RevaluationRateFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/ScenarioFormSpec.scala
+++ b/test/forms/ScenarioFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/helpers/BaseSpec.scala
+++ b/test/helpers/BaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/helpers/RandomNino.scala
+++ b/test/helpers/RandomNino.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/CalculationResponseSpec.scala
+++ b/test/models/CalculationResponseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/GmpDateSpec.scala
+++ b/test/models/GmpDateSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/NinoSpec.scala
+++ b/test/models/NinoSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/UploadStatusSpec.scala
+++ b/test/models/UploadStatusSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/UpscanCallbackSpec.scala
+++ b/test/models/UpscanCallbackSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/BulkRequestCreationServiceSpec.scala
+++ b/test/services/BulkRequestCreationServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/SessionServiceSpec.scala
+++ b/test/services/SessionServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/UpscanServiceSpec.scala
+++ b/test/services/UpscanServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/utils/GmpViewSpec.scala
+++ b/test/utils/GmpViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/utils/JSoupMatchers.scala
+++ b/test/utils/JSoupMatchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/utils/WireMockHelper.scala
+++ b/test/utils/WireMockHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/validation/CsvLineValidatorSpec.scala
+++ b/test/validation/CsvLineValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/validation/DateValidatorSpec.scala
+++ b/test/validation/DateValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/validation/NinoValidatorSpec.scala
+++ b/test/validation/NinoValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/validation/SconValidatorSpec.scala
+++ b/test/validation/SconValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/BulkReferenceSpec.scala
+++ b/test/views/html/BulkReferenceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/BulkRequestReceivedSpec.scala
+++ b/test/views/html/BulkRequestReceivedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/BulkResultsNotFoundSpec.scala
+++ b/test/views/html/BulkResultsNotFoundSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/BulkResultsSpec.scala
+++ b/test/views/html/BulkResultsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/BulkWrongUserSpec.scala
+++ b/test/views/html/BulkWrongUserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/ContributionsEarningsSpec.scala
+++ b/test/views/html/ContributionsEarningsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/DashboardSpec.scala
+++ b/test/views/html/DashboardSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/DateOfLeavingSpec.scala
+++ b/test/views/html/DateOfLeavingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/EqualiseSpec.scala
+++ b/test/views/html/EqualiseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/FailureSpec.scala
+++ b/test/views/html/FailureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/IncorrectlyEncodedSpec.scala
+++ b/test/views/html/IncorrectlyEncodedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import play.api.i18n.Messages
 import play.twirl.api.Html
 import utils.GmpViewSpec
-import views.html.gmp_main
+import _old
 
 class IncorrectlyEncodedSpec extends GmpViewSpec {
 

--- a/test/views/html/InflationProofSpec.scala
+++ b/test/views/html/InflationProofSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/MemberDetailsViewSpec.scala
+++ b/test/views/html/MemberDetailsViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/MoreBulkResultsSpec.scala
+++ b/test/views/html/MoreBulkResultsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/PensionDetailsSpec.scala
+++ b/test/views/html/PensionDetailsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/ResultsSpec.scala
+++ b/test/views/html/ResultsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/RevaluationRateSpec.scala
+++ b/test/views/html/RevaluationRateSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/RevaluationSpec.scala
+++ b/test/views/html/RevaluationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/ScenarioSpec.scala
+++ b/test/views/html/ScenarioSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/ThankYouSpec.scala
+++ b/test/views/html/ThankYouSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import play.twirl.api.Html
 import utils.GmpViewSpec
 
 class ThankYouSpec extends GmpViewSpec{
-  lazy val gmpMain = app.injector.instanceOf[gmp_main]
+  lazy val gmpMain = app.injector.instanceOf[]
   override def view: Html = new views.html.thank_you(gmpMain)()
 
   "Thank you page" must {

--- a/test/views/html/UnauthorisedSpec.scala
+++ b/test/views/html/UnauthorisedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/html/UploadFileSpec.scala
+++ b/test/views/html/UploadFileSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Add HMRC layout, update gmp main to use layout, and rename calls from @this(gmpMain: gmp_main) to @this(gmpMain:gmp_main_old) to keep track of pages that still need to upgrade to new components